### PR TITLE
fix: dynamic route 404 on Vercel

### DIFF
--- a/microsponsor-frontend/src/pages/scholarships/[id].tsx
+++ b/microsponsor-frontend/src/pages/scholarships/[id].tsx
@@ -190,3 +190,8 @@ export default function ScholarshipDetail() {
     </div>
   );
 }
+
+// Makes Vercel create a serverless function so dynamic routing works
+export async function getServerSideProps() {
+  return { props: {} };
+}

--- a/microsponsor-frontend/src/pages/students/[address].tsx
+++ b/microsponsor-frontend/src/pages/students/[address].tsx
@@ -180,3 +180,8 @@ export default function StudentProfile() {
     </div>
   );
 }
+
+// Makes Vercel create a serverless function so dynamic routing works
+export async function getServerSideProps() {
+  return { props: {} };
+}


### PR DESCRIPTION
Dynamic route pages `/scholarships/[id]` and `/students/[address]` were marked as `○ (Static)` — Vercel served them as static CDN files and could not map `/scholarships/123` to the `[id]` handler, returning 404.

Adding `getServerSideProps` forces Next.js to create serverless functions for these routes, which Vercel routes correctly. Both pages now show `ƒ (Dynamic)` in the build output.